### PR TITLE
fix: The response content cannot be parsed because the Internet Explo…

### DIFF
--- a/RapidReleaseTI/MachineKeyScan.ps1
+++ b/RapidReleaseTI/MachineKeyScan.ps1
@@ -18,7 +18,7 @@ param(
 $DisclosedKeysUrl = "https://github.com/microsoft/mstic/blob/master/RapidReleaseTI/MachineKeys.csv"
 
 try {
-    $DisclosedKeys = Invoke-WebRequest -Uri $DisclosedKeysUrl -ErrorAction Stop
+    $DisclosedKeys = Invoke-WebRequest -Uri $DisclosedKeysUrl -ErrorAction Stop -UseBasicParsing
     if (-not $DisclosedKeys -or -not $DisclosedKeys.Content) {
         Write-Host -ForegroundColor Yellow "Error: Downloaded content from $DisclosedKeysUrl is empty."
         exit 1


### PR DESCRIPTION
…rer engine is not available

There is an error when trying to run the script: `Error downloading MachineKeys.txt: The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again`

When adding the `UseBasicParameter` the script works.