### PR TITLE
Fix typo in MicrosoftMapping.json

### DIFF
--- a/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json
+++ b/PublicFeeds/ThreatActorNaming/MicrosoftMapping.json
@@ -166,12 +166,12 @@
 	{
 		"Threat actor name": "Hazel Sandstorm",
 		"Origin/Threat": "Iran",
-		"Other names": "EUROPIUM, HELIX KITTEN, COLBALT GYPSY, Crambus, OilRig, APT34"
+		"Other names": "EUROPIUM, HELIX KITTEN, COBALT GYPSY, Crambus, OilRig, APT34"
 	},
 	{
 		"Threat actor name": "Heart Typhoon",
 		"Origin/Threat": "China",
-		"Other names": "HELIUM, AURORA PANDA, APT17, Hidden Lynx, ATG3, Red Typhon, KAOS, TG-8153, SportsFans, DeputyDog, Tailgater"
+		"Other names": "HELIUM, AURORA PANDA, APT17, Hidden Lynx, ATG3, Red Typhoon, KAOS, TG-8153, SportsFans, DeputyDog, Tailgater"
 	},
 	{
 		"Threat actor name": "Hexagon Typhoon",


### PR DESCRIPTION
Corrected two typos:
- 'COLBALT GYPSY' → 'COBALT GYPSY'
- 'Red Typhon' → 'Red Typhoon'